### PR TITLE
Enable rule with best guess at exceptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,27 @@ module.exports = {
       ],
     }],
     'import/prefer-default-export': 'off',
+    'import/no-internal-modules': [ 'error', {
+      'allow': [
+        // stable
+        'fp-ts/*',
+        'io-ts/*',
+        'io-ts-types/*',
+        'remarkable/linkify',
+        '**/types/*',
+        '**/types/codecs/*',
+        '**/shared-read-models/*',
+        '**/infrastructure/*',
+        '**/third-parties/*',
+        // unstable
+        '**/data/bootstrap-groups', // aim to remove bootstrap-groups
+        '**/shared-components/**', // aim to make it shared-components/*
+        '**/types/*.helper', // delete because it's only used in tests
+        '**/src/*', // aim to remove
+        '**/ingest/*', // unclear whether this dependency direction from third-parties into ingest is legit
+        '**/../list-page/**' // aim to remove when ncrc-featured-articles-page does not exist anymore
+      ],
+    }],
     'max-len': ['error', 120, 2, {
       ignoreComments: false,
       ignoreRegExpLiterals: true,
@@ -119,6 +140,12 @@ module.exports = {
         'jest/prefer-to-be': 'error',
         'jest/prefer-expect-resolves': 'off',
         'jest/unbound-method': 'off',
+      },
+    },
+    {
+      files: ['test/**/*.ts'],
+      rules: {
+        'import/no-internal-modules': 'off',
       },
 
     },


### PR DESCRIPTION
Remaining cases have lots of legitimate cohesion problems:
```

> @ lint /app
> run-p --aggregate-output --continue-on-error --print-label --silent lint:**

[lint:eslint         ] 
[lint:eslint         ] /app/.eslintrc.js
[lint:eslint         ]   73:36  error  There should be no space after '['           array-bracket-spacing
[lint:eslint         ]   74:7   error  Unnecessarily quoted property 'allow' found  quote-props
[lint:eslint         ]   91:29  error  Missing trailing comma                       @typescript-eslint/comma-dangle
[lint:eslint         ] 
[lint:eslint         ] /app/feature-test/record-evaluation.test.ts
[lint:eslint         ]   8:48  error  Reaching to "../test/helpers" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/article-page/index.ts
[lint:eslint         ]   1:37  error  Reaching to "./activity-page/activity-page" is not allowed  import/no-internal-modules
[lint:eslint         ]   2:33  error  Reaching to "./meta-page/meta-page" is not allowed          import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/article-page/project-has-user-saved-article.ts
[lint:eslint         ]   4:34  error  Reaching to "../save-article/article-save-state" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/article-page/render-save-article.ts
[lint:eslint         ]   4:32  error  Reaching to "../save-article/render-save-form" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/docmaps/docmap-index/docmap-index.ts
[lint:eslint         ]   10:63  error  Reaching to "../docmap/generate-docmap-view-model" is not allowed  import/no-internal-modules
[lint:eslint         ]   11:26  error  Reaching to "../docmap/to-docmap" is not allowed                   import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/docmaps/docmap-index/identify-all-possible-index-entries.ts
[lint:eslint         ]   15:36  error  Reaching to "../docmap/publisher-account-id" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/follow/execute-if-authenticated.ts
[lint:eslint         ]   11:33  error  Reaching to "../http/render-error-page" is not allowed       import/no-internal-modules
[lint:eslint         ]   12:38  error  Reaching to "../http/require-authentication" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/group-page/content-component.ts
[lint:eslint         ]   6:44  error  Reaching to "./about/about" is not allowed               import/no-internal-modules
[lint:eslint         ]   7:31  error  Reaching to "./followers/find-followers" is not allowed  import/no-internal-modules
[lint:eslint         ]   8:52  error  Reaching to "./followers/followers" is not allowed       import/no-internal-modules
[lint:eslint         ]   9:44  error  Reaching to "./lists/lists" is not allowed               import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/group-page/group-page.ts
[lint:eslint         ]   12:36  error  Reaching to "../follow/render-follow-toggle" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/group-page/lists/lists.ts
[lint:eslint         ]   7:36  error  Reaching to "../../ncrc-featured-articles-page/lists" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/home-page/cards/user-list-card.ts
[lint:eslint         ]   10:36  error  Reaching to "../../user-page/user-list-card/get-user-list-details" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/http/finish-command.ts
[lint:eslint         ]   6:38  error  Reaching to "../follow/finish-follow-command" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/http/router.ts
[lint:eslint         ]   22:39  error  Reaching to "./redirects/redirect-group-id-to-slug" is not allowed           import/no-internal-modules
[lint:eslint         ]   23:40  error  Reaching to "./redirects/redirect-user-id-to-handle" is not allowed          import/no-internal-modules
[lint:eslint         ]   28:33  error  Reaching to "../docmaps/docmap" is not allowed                               import/no-internal-modules
[lint:eslint         ]   29:29  error  Reaching to "../docmaps/docmap-index" is not allowed                         import/no-internal-modules
[lint:eslint         ]   35:8   error  Reaching to "../group-page/group-page" is not allowed                        import/no-internal-modules
[lint:eslint         ]   40:81  error  Reaching to "../list-page/list-page" is not allowed                          import/no-internal-modules
[lint:eslint         ]   41:32  error  Reaching to "../menu-page/menu-page-layout" is not allowed                   import/no-internal-modules
[lint:eslint         ]   43:97  error  Reaching to "../ncrc-featured-articles-page/page" is not allowed             import/no-internal-modules
[lint:eslint         ]   46:38  error  Reaching to "../respond/finish-respond-command" is not allowed               import/no-internal-modules
[lint:eslint         ]   47:36  error  Reaching to "../respond/save-respond-command" is not allowed                 import/no-internal-modules
[lint:eslint         ]   48:31  error  Reaching to "../save-article/execute-unsave-article-command" is not allowed  import/no-internal-modules
[lint:eslint         ]   49:42  error  Reaching to "../save-article/finish-save-article-command" is not allowed     import/no-internal-modules
[lint:eslint         ]   50:40  error  Reaching to "../save-article/save-save-article-command" is not allowed       import/no-internal-modules
[lint:eslint         ]   51:49  error  Reaching to "../sciety-feed-page/sciety-feed-page" is not allowed            import/no-internal-modules
[lint:eslint         ]   61:26  error  Reaching to "../user-page/user-page" is not allowed                          import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/http/server.ts
[lint:eslint         ]   13:42  error  Reaching to "../user-account/create-account-if-necessary" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/index.ts
[lint:eslint         ]   6:30  error  Reaching to "./http/router" is not allowed  import/no-internal-modules
[lint:eslint         ]   7:41  error  Reaching to "./http/server" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/infrastructure/create-infrastructure.ts
[lint:eslint         ]   30:36  error  Reaching to "../shared-read-models/lists/list-creation-data" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/infrastructure/fetch-hypothesis-annotation.ts
[lint:eslint         ]   10:60  error  Reaching to "./codecs/HypothesisAnnotation" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/infrastructure/fetch-ncrc-review.ts
[lint:eslint         ]   11:25  error  Reaching to "../third-parties/ncrc/sheet-id" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/ingest/fetch-ncrc-evaluations.ts
[lint:eslint         ]   10:25  error  Reaching to "../third-parties/ncrc/sheet-id" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/ingest/update-event-data.ts
[lint:eslint         ]   11:43  error  Reaching to "../third-parties/prelights/fetch-prelights-evaluations" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/list-page/evaluated-articles-list/to-page-of-cards.ts
[lint:eslint         ]   9:64  error  Reaching to "../../ncrc-featured-articles-page/articles-list/to-card-view-model" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/ncrc-featured-articles-page/articles-list/articlesList.ts
[lint:eslint         ]   9:44  error  Reaching to "../../list-page/evaluated-articles-list/static-messages" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/ncrc-featured-articles-page/articles-list/to-card-view-model.ts
[lint:eslint         ]   3:43  error  Reaching to "../../list-page/evaluated-articles-list/render-article-error-card" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/ncrc-featured-articles-page/articles-list/to-page-of-cards.ts
[lint:eslint         ]   8:33  error  Reaching to "../../list-page/evaluated-articles-list/render-component" is not allowed  import/no-internal-modules
[lint:eslint         ]   9:47  error  Reaching to "../../list-page/evaluated-articles-list/static-messages" is not allowed   import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/ncrc-featured-articles-page/page.ts
[lint:eslint         ]   10:37  error  Reaching to "./articles-list/articlesList" is not allowed          import/no-internal-modules
[lint:eslint         ]   12:33  error  Reaching to "../list-page/header/render-component" is not allowed  import/no-internal-modules
[lint:eslint         ]   13:33  error  Reaching to "../list-page/render-page" is not allowed              import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/sciety-feed-page/cards/group-evaluated-multiple-articles-card.ts
[lint:eslint         ]   5:29  error  Reaching to "../../domain-events/domain-event" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/sciety-feed-page/cards/user-saved-article-to-a-list-card.ts
[lint:eslint         ]   10:44  error  Reaching to "../../user-page/static-messages" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/shared-read-models/groups/construct-read-model.ts
[lint:eslint         ]   4:37  error  Reaching to "../../domain-events/type-guards" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/shared-read-models/lists/construct-lists-read-model.ts
[lint:eslint         ]   7:34  error  Reaching to "../../domain-events/list-created-event" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/shared-read-models/lists/list-creation-data.ts
[lint:eslint         ]   1:47  error  Reaching to "../../domain-events/list-created-event" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/user-account/create-account-if-necessary.ts
[lint:eslint         ]   18:36  error  Reaching to "../domain-events/user-created-account-event" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/user-list-page/saved-articles/saved-articles.ts
[lint:eslint         ]   11:34  error  Reaching to "../../save-article/render-unsave-form" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/user-list-page/user-list-page.ts
[lint:eslint         ]    6:48  error  Reaching to "./saved-articles/saved-article-dois" is not allowed  import/no-internal-modules
[lint:eslint         ]    7:59  error  Reaching to "./saved-articles/saved-articles" is not allowed      import/no-internal-modules
[lint:eslint         ]   16:44  error  Reaching to "../user-page/static-messages" is not allowed         import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] /app/src/user-page/user-page.ts
[lint:eslint         ]   5:54  error  Reaching to "./follow-list/follow-list" is not allowed                 import/no-internal-modules
[lint:eslint         ]   6:34  error  Reaching to "./follow-list/project-followed-group-ids" is not allowed  import/no-internal-modules
[lint:eslint         ] 
[lint:eslint         ] ✖ 64 problems (64 errors, 0 warnings)
[lint:eslint         ]   3 errors and 0 warnings potentially fixable with the `--fix` option.
[lint:eslint         ] 
```