### PR TITLE
Substitute monolithic googleapis with smaller @googleapis/sheets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -794,6 +794,14 @@
         "stoppable": "^1.1.0"
       }
     },
+    "@googleapis/sheets": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sheets/-/sheets-4.0.0.tgz",
+      "integrity": "sha512-K/zdavjI80ofgT7p+5kD5Se3eTuPFJmup19IONkGdXQuuFKgh7HR3txoX2BUg5wX4b+oNW9XcXcfE3yQPWO+8w==",
+      "requires": {
+        "googleapis-common": "^6.0.3"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -3702,7 +3710,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "assign-symbols": {
@@ -4059,6 +4067,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
+    "bignumber.js": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -4327,7 +4340,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -5641,7 +5654,7 @@
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
       "dev": true,
       "requires": {
         "asap": "^2.0.0",
@@ -7874,9 +7887,9 @@
       "dev": true
     },
     "fast-text-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
     },
     "fast-xml-parser": {
       "version": "4.0.11",
@@ -8167,78 +8180,23 @@
       "dev": true
     },
     "gaxios": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-      "integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.2.tgz",
+      "integrity": "sha512-TjtV2AJOZoMQqRYoy5eM8cCQogYwazWNYLQ72QB0kwa6vHHruYkGmhhyrlzbmgNHK1dNnuP2WSH81urfzyN2Og==",
       "requires": {
-        "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-        }
+        "node-fetch": "^2.6.7"
       }
     },
     "gcp-metadata": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
-      "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.1.tgz",
+      "integrity": "sha512-jiRJ+Fk7e8FH68Z6TLaqwea307OktJpDjmYnU7/li6ziwvVvU2RlrCyQo5vkdeP94chm0kcSCOOszvmuaioq3g==",
       "requires": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "gaxios": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
-          "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
-          "requires": {
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.6.7"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        }
       }
     },
     "gensync": {
@@ -8642,9 +8600,9 @@
       }
     },
     "google-auth-library": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.1.0.tgz",
-      "integrity": "sha512-J/fNXEnqLgbr3kmeUshZCtHQia6ZiNbbrebVzpt/+LTeY6Ka9CtbQvloTjVGVO7nyYbs0KYeuIwgUC/t2Gp1Jw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.6.0.tgz",
+      "integrity": "sha512-y6bw1yTWMVgs1vGJwBZ3uu+uIClfgxQfsEVcTNKjQeNQOVwox69+ZUgTeTAzrh+74hBqrk1gWyb9RsQVDI7seg==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -8652,61 +8610,24 @@
         "fast-text-encoding": "^1.0.0",
         "gaxios": "^5.0.0",
         "gcp-metadata": "^5.0.0",
-        "gtoken": "^6.0.0",
+        "gtoken": "^6.1.0",
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
         "arrify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
           "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-        },
-        "gaxios": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
-          "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
-          "requires": {
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.6.7"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
         }
       }
     },
     "google-p12-pem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.0.tgz",
-      "integrity": "sha512-lRTMn5ElBdDixv4a86bixejPSRk1boRtUowNepeKEVvYiFlkLuAJUVpEz6PfObDHYEKnZWq/9a2zC98xu62A9w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
       "requires": {
         "node-forge": "^1.3.1"
-      }
-    },
-    "googleapis": {
-      "version": "108.0.1",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-108.0.1.tgz",
-      "integrity": "sha512-NKYTMfQH1xVl38Efj4UAwYq/9j+vc/iaqULfG3dSBK4vQHhsYKgKN6agMrgzlWo3NA8ivwb/0bToxZxnhxj7Bg==",
-      "requires": {
-        "google-auth-library": "^8.0.2",
-        "googleapis-common": "^6.0.0"
       }
     },
     "googleapis-common": {
@@ -8722,17 +8643,6 @@
         "uuid": "^9.0.0"
       },
       "dependencies": {
-        "gaxios": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
-          "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
-          "requires": {
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.6.7"
-          }
-        },
         "qs": {
           "version": "6.11.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -8774,11 +8684,11 @@
       "dev": true
     },
     "gtoken": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.0.tgz",
-      "integrity": "sha512-WPZcFw34wh2LUvbCUWI70GDhOlO7qHpSvFHFqq7d3Wvsf8dIJedE0lnUdOmsKuC0NgflKmF0LxIF38vsGeHHiQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
       "requires": {
-        "gaxios": "^4.0.0",
+        "gaxios": "^5.0.1",
         "google-p12-pem": "^4.0.0",
         "jws": "^4.0.0"
       }
@@ -11462,13 +11372,6 @@
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "requires": {
         "bignumber.js": "^9.0.0"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-        }
       }
     },
     "json-buffer": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.11.2",
+    "@googleapis/sheets": "^4.0.0",
     "@koa/router": "^12.0.0",
     "@rdfjs/data-model": "^1.3.4",
     "@rdfjs/fetch-lite": "^2.1.2",
@@ -22,8 +23,7 @@
     "escape-goat": "^3.0.0",
     "fast-xml-parser": "^4.0.11",
     "fp-ts": "^2.13.1",
-    "googleapis": "^108.0.1",
-    "googleapis-common": "6.0.3",
+    "googleapis-common": "^6.0.3",
     "http-status-codes": "^2.2.0",
     "io-ts": "^2.2.19",
     "io-ts-reporters": "^2.0.1",

--- a/src/infrastructure/fetch-ncrc-review.ts
+++ b/src/infrastructure/fetch-ncrc-review.ts
@@ -1,8 +1,8 @@
+import { auth, sheets, sheets_v4 } from '@googleapis/sheets';
 import * as E from 'fp-ts/Either';
 import * as RA from 'fp-ts/ReadonlyArray';
 import * as TE from 'fp-ts/TaskEither';
 import { pipe } from 'fp-ts/function';
-import { google, sheets_v4 } from 'googleapis';
 import * as t from 'io-ts';
 import * as PR from 'io-ts/PathReporter';
 import { constructNcrcReview, NcrcReview } from './construct-ncrc-review';
@@ -60,18 +60,14 @@ const querySheet = (logger: Logger) => <A>(
   params: Params$Resource$Spreadsheets$Values$Get,
   decoder: t.Decoder<unknown, A>,
 ) => {
-  const auth = new google.auth.GoogleAuth({
+  const myauth = new auth.GoogleAuth({
     keyFile: '/var/run/secrets/app/.gcp-ncrc-key.json',
     scopes: ['https://www.googleapis.com/auth/cloud-platform', 'https://www.googleapis.com/auth/spreadsheets.readonly'],
   });
 
-  google.options({
-    auth,
-  });
-
   return pipe(
     TE.tryCatch(
-      async () => google.sheets('v4').spreadsheets.values.get(params),
+      async () => sheets({ version: 'v4', auth: myauth }).spreadsheets.values.get(params),
       (error) => {
         logger('error', 'Error fetching Google sheet', { error });
         return DE.unavailable;

--- a/src/ingest/fetch-google-sheet.ts
+++ b/src/ingest/fetch-google-sheet.ts
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks';
+import { auth, sheets, sheets_v4 } from '@googleapis/sheets';
 import * as TE from 'fp-ts/TaskEither';
-import { google, sheets_v4 } from 'googleapis';
 import { GaxiosResponse } from 'googleapis-common';
 import Schema$ValueRange = sheets_v4.Schema$ValueRange;
 
@@ -9,15 +9,14 @@ const getSheets = async (
   range: string,
 ): Promise<GaxiosResponse<Schema$ValueRange>> => {
   const startTime = performance.now();
-  const auth = new google.auth.GoogleAuth({
+  const myauth = new auth.GoogleAuth({
     keyFile: '/var/run/secrets/app/.gcp-ncrc-key.json',
     scopes: [
       'https://www.googleapis.com/auth/cloud-platform',
       'https://www.googleapis.com/auth/spreadsheets.readonly',
     ],
   });
-  google.options({ auth });
-  return google.sheets('v4').spreadsheets.values.get({ spreadsheetId, range }).finally(() => {
+  return sheets({ version: 'v4', auth: myauth }).spreadsheets.values.get({ spreadsheetId, range }).finally(() => {
     if (process.env.INGEST_DEBUG && process.env.INGEST_DEBUG.length > 0) {
       const endTime = performance.now();
       process.stdout.write(`Fetched Google sheet ${spreadsheetId}/${range} (${Math.round(endTime - startTime)}ms)\n`);


### PR DESCRIPTION
Following https://effectivetypescript.com/2022/07/30/treemap-for-source-files/

Reduces compilation on my laptop from ~13s to ~3s (without Google Meet running) and from ~18s to ~6s (with Google Meet).

Tested with @davidcmoulton that we can still ingest NCRC reviews from Google Sheets, and display them in the browser.

