### PR TITLE
Restart all containers after reboot or crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,9 @@ services:
     healthcheck:
       test: pg_isready --username $$POSTGRES_USER --dbnam $$POSTGRES_DB || exit 1
       interval: 5s
+    restart: unless-stopped
+
   cache:
     container_name: sciety_cache
     image: redis:6.2-alpine
+    restart: unless-stopped


### PR DESCRIPTION
See [docker documentation](https://docs.docker.com/config/containers/start-containers-automatically/).

## Scenarios tested

- [x] `make dev` runs
- [x] `make clean-db` on a running `make dev` correctly stops all containers and removes all data
- [x] `make prod`
- [x] `make clean-db` on a running `make prod` correctly stops all containers and removes all data
- [x] `make taiko` runs
- [x] `make backstop-test` runs
- [x] after a reboot, all containers are started and the `sciety_app` container does not crash indefinitely