### PR TITLE
Target the Node.js module system, rather than a pure CommonJS or EcmaScript Modules host

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": [
       "es2020"
     ],
-    "module": "commonjs",
+    "module": "node16",
     "outDir": "build",
     "pretty": true,
     "strict": true,


### PR DESCRIPTION
> A common misconception is that [`node16` and `nodenext`](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext) only emit ES modules. In reality, `node16` and `nodenext` describe versions of Node.js that support ES modules, not just projects that use ES modules. Both ESM and CommonJS emit are supported, based on the [detected module format](https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection) of each file. Because `node16` and `nodenext` are the only module options that reflect the complexities of Node.js’s dual module system, they are **the only correct module options for all apps and libraries that are intended to run in Node.js v12 or later**, whether they use ES modules or not.

Also shown in the [`tsconfig` suggested configuration](https://www.npmjs.com/package/@tsconfig/node18).

To use EcmaScript Modules coming from any library, we will likely need to start emitting EcmaScript Modules, as
> `require` cannot reference an ES module. For TypeScript, this includes `import` statements in files that are [detected](https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection) to be CommonJS modules, since those `import` statements will be transformed to `require` calls in the emitted JavaScrip

This change should still emit CommonJS modules. To start emitting ES modules, try:
> adding ["type": "module"](https://nodejs.org/api/packages.html#type) to the project package.json