### PR TITLE
Avoid false negatives in backstop-test

### DIFF
--- a/backstop.json
+++ b/backstop.json
@@ -19,6 +19,9 @@
   ],
   "misMatchThreshold": 0,
   "onReadyScript": "puppet/onReady.js",
+  "resembleOutputOptions": {
+    "usePreciseMatching": true
+  },
   "scenarios": [
     {
       "label": "Home page",


### PR DESCRIPTION
Enable usePreciseMatching to truly have a mismatch threshold of 0
https://github.com/garris/BackstopJS/blob/master/README.md#modifying-output-settings-of-image-diffs