### PR TITLE
Upgrade Taiko to 1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "stylelint": "^16.14.0",
         "stylelint-config-sass-guidelines": "11.1",
         "stylelint-order": "^6.0.4",
-        "taiko": "^1.4.0",
+        "taiko": "^1.4.3",
         "ts-unused-exports": "^11.0.1",
         "tsx": "^4.19.2",
         "typescript": "^5.5.4"
@@ -20589,11 +20589,12 @@
       "license": "MIT"
     },
     "node_modules/taiko": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/taiko/-/taiko-1.4.0.tgz",
-      "integrity": "sha512-f3Fqd5M8kBbV1qN7XyH3/t+hSY3Sm3+ZisBalg5ChOT8oELmgpGaxjgV4amSWYYLWKitbVATs4DvUGZXd1t8OQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/taiko/-/taiko-1.4.3.tgz",
+      "integrity": "sha512-KuJePiVqDXJswJW1nwkLHSOnlHynfkE6yaVQQ2mIAg2AXAMnoeUat19q9R2NUdZWUuuuE+Bhws65vahw0+9ZMg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "chrome-remote-interface": "^0.33.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "stylelint": "^16.14.0",
     "stylelint-config-sass-guidelines": "11.1",
     "stylelint-order": "^6.0.4",
-    "taiko": "^1.4.0",
+    "taiko": "^1.4.3",
     "ts-unused-exports": "^11.0.1",
     "tsx": "^4.19.2",
     "typescript": "^5.5.4"


### PR DESCRIPTION
Was originally merged in https://github.com/sciety/sciety/pull/3731 but failed in CI on `main`.

Other tests:
- green on @erkannt machine, @LinaKind machine
- red on @giorgiosironi machine, intermittently (`multiple-logins › when I am on the article page and I log in successfully › when I log out and go to the About page › when I log in successfully again › i am still on the About page [...] Navigation took more than 30000ms. Please increase the navigationTimeout.`)